### PR TITLE
Draft: Add alternative reward functions.

### DIFF
--- a/sapai_gym/SuperAutoPetsEnv.py
+++ b/sapai_gym/SuperAutoPetsEnv.py
@@ -135,7 +135,12 @@ class SuperAutoPetsEnv(gym.Env):
         assert 0 <= self.player.wins <= 10
         if self.valid_actions_only:
             assert self.bad_action_reward_sum == 0
-        return self.player.wins / 10 + self.bad_action_reward_sum
+        # Linear reward
+        # return self.player.wins / 10 + self.bad_action_reward_sum
+        # Quadratic reward
+        # return (self.player.wins * self.player.wins) / 100 + self.bad_action_reward_sum
+        # Exponential reward
+        return (2**self.player.wins  / 1024 if self.player.wins  != 0 else 0) + self.bad_action_reward_sum
 
     def _avail_end_turn(self):
         action_dict = dict()


### PR DESCRIPTION
In this PR, we consider adding alternative reward functions the environment.

As someone with little RL experience, I'm generally having a difficult time getting my PPO-based agent to perform well in later turns. I'm currently experimenting with alternative reward functions that increase the reward non-linearly as the number of wins increases. From the bit of experimentation that I've done, this seems to improve agent performance slightly.

In a revised version of this PR, would it be of-interest to allow the user to provide an arbitrary reward function `Callable` as an input to the environment?