### PR TITLE
Workflow CI + wheel

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,61 @@
+name: build
+
+on: 
+  push: 
+    branches:
+      - "*"
+  pull_request: 
+    branches: 
+      - "*"
+  workflow_dispatch: 
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+
+    - name: Install dependencies
+      run: pip install wheel setuptools
+
+    - name: Build wheel
+      run: python setup.py bdist_wheel
+
+    - name: Upload Python wheel
+      uses: actions/upload-artifact@v2
+      with:
+        name: Python wheel
+        path: ${{github.workspace}}/dist/sapai_gym-*.whl
+        if-no-files-found: error
+
+  test:
+    needs: build
+    runs-on: ${{matrix.os}}
+    strategy:
+      max-parallel: 10
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9, 3]
+        os: [ubuntu-18.04, windows-2019, macos-11]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{matrix.python-version}}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{matrix.python-version}}
+
+    - name: Download artifact
+      uses: actions/download-artifact@master
+      with:
+        name: "Python wheel"
+
+    - name: Install wheel
+      run: pip install --find-links=${{github.workspace}} sapai_gym
+
+    - name: Test library accessibility
+      run: python -c "import sapai_gym"
+

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ are divided by 50, to remain in [0, 1]. All other features are scaled to [0, 1].
 
 ## Opponent Generation
 
-If Super Auto Pets, when you end your turn in the shop, you fight an opponent. The question of how to generate this
+In Super Auto Pets, when you end your turn in the shop, you fight an opponent. The question of how to generate this
 opponent when simulating Super Auto Pets in a controlled environment is interesting and could have multiple different answers and implementations.
 
 In order to allow flexibility in `sapai-gym`, an opponent generator is passed into the environment, which the environment

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
       name='sapai_gym',
-      version='0.1',
+      version='0.1.0',
       packages=find_packages(),
       install_requires=[
           "sapai @ git+https://github.com/manny405/sapai.git@main",


### PR DESCRIPTION
Similar as mentioned in this PR https://github.com/manny405/sapai/pull/78, I created a CI for generating a binary wheel for the package, and added tests for installing and importing it using different operating systems and python versions.

I also thought it was a good idea to use versioning `major.minor.patch` instead of the old structure.

I will expand upon the unit tests and report any issues I observe.