### PR TITLE
Use correct scikit-learn PyPI project

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(
       install_requires=[
           "sapai @ git+https://github.com/manny405/sapai.git@main",
           "gym~=0.21.0",
-          "sklearn"
+          "scikit-learn"
       ]
 )


### PR DESCRIPTION
I observed that `sklearn` was set as a dependency:
https://github.com/alexdriedger/sapai-gym/blob/master/setup.py#L10

That is the wrong PyPI project. If you go the the `sklearn` PyPI page:
https://pypi.org/project/sklearn/

You will see that the README has one line:
- Use [scikit-learn](https://pypi.python.org/pypi/scikit-learn/) instead.

Hence, I substituted `sklearn` with `scikit-learn`.

Swapping dependency does not affect the code, as both use `import sklearn`, which is probably why `sklearn` was added mistakenly as a dependency.